### PR TITLE
Add multi-select questions and shuffle quiz order

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -106,9 +106,28 @@ body {
 }
 
 .btn-primary {
-	background: linear-gradient(135deg, #1976d2 0%, #1565c0 100%);
-	color: white;
-	width: 100%;
+        background: linear-gradient(135deg, #1976d2 0%, #1565c0 100%);
+        color: white;
+        width: 100%;
+}
+
+.btn-secondary {
+        background: white;
+        color: #1976d2;
+        border: 2px solid #1976d2;
+        padding: 10px 20px;
+        font-size: 0.95rem;
+}
+
+.btn-secondary:hover {
+        background: rgba(25, 118, 210, 0.1);
+}
+
+.btn-secondary:disabled {
+        background: #f5f5f5;
+        color: #9e9e9e;
+        border-color: #e0e0e0;
+        cursor: not-allowed;
 }
 
 .btn-primary:hover {
@@ -277,14 +296,22 @@ body {
 }
 
 .question-navigation {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        align-items: stretch;
 }
 
 .navigation-hint {
-	font-size: 0.9rem;
-	color: #666;
+        font-size: 0.9rem;
+        color: #666;
+}
+
+.navigation-buttons {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        width: 100%;
 }
 
 /* Answer Feedback */

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,18 +32,19 @@ function App() {
 
 	const {
 		currentQuestion,
-		selectedAnswer,
-		showResults,
-		quizStarted,
-		showAnswerResult,
-		totalQuestions,
-		currentQ,
-		handleAnswerSelect,
-		handleNextQuestion,
-		calculateScore,
-		resetQuiz,
-		startQuiz,
-	} = useQuiz(questionsData?.questions || [])
+                selectedAnswers,
+                showResults,
+                quizStarted,
+                showAnswerResult,
+                totalQuestions,
+                currentQ,
+                handleAnswerSelect,
+                handleSubmitAnswer,
+                handleNextQuestion,
+                calculateScore,
+                resetQuiz,
+                startQuiz,
+        } = useQuiz(questionsData?.questions || [])
 
 	if (loading) {
 		return (
@@ -105,14 +106,15 @@ function App() {
 					totalQuestions={totalQuestions}
 				/>
 
-				<QuestionCard
-					question={currentQ}
-					selectedAnswer={selectedAnswer}
-					onAnswerSelect={handleAnswerSelect}
-					onNext={handleNextQuestion}
-					isLastQuestion={currentQuestion === totalQuestions - 1}
-					showAnswerResult={showAnswerResult}
-				/>
+                                <QuestionCard
+                                        question={currentQ}
+                                        selectedAnswers={selectedAnswers}
+                                        onAnswerSelect={handleAnswerSelect}
+                                        onSubmitAnswer={handleSubmitAnswer}
+                                        onNext={handleNextQuestion}
+                                        isLastQuestion={currentQuestion === totalQuestions - 1}
+                                        showAnswerResult={showAnswerResult}
+                                />
 			</div>
 		</div>
 	)

--- a/src/components/QuestionCard.jsx
+++ b/src/components/QuestionCard.jsx
@@ -1,14 +1,38 @@
 import React from "react"
 
 const QuestionCard = ({
-	question,
-	selectedAnswer,
-	onAnswerSelect,
-	onNext,
-	isLastQuestion,
-	showAnswerResult,
+        question,
+        selectedAnswers,
+        onAnswerSelect,
+        onSubmitAnswer,
+        onNext,
+        isLastQuestion,
+        showAnswerResult,
 }) => {
-	const isCorrect = selectedAnswer === question.correctAnswer
+        if (!question) {
+                return null
+        }
+
+        const correctAnswers = Array.isArray(question.correctAnswers)
+                ? question.correctAnswers
+                : [question.correctAnswer]
+        const isMultiple = correctAnswers.length > 1
+        const normalizedSelected = Array.isArray(selectedAnswers)
+                ? selectedAnswers
+                : typeof selectedAnswers === "number"
+                ? [selectedAnswers]
+                : []
+        const sortedCorrectAnswers = [...correctAnswers].sort((a, b) => a - b)
+        const sortedSelectedAnswers = [...normalizedSelected].sort((a, b) => a - b)
+
+        const isCorrect = showAnswerResult
+                ? isMultiple
+                        ? sortedCorrectAnswers.every(
+                                  (answer, idx) => sortedSelectedAnswers[idx] === answer,
+                          ) &&
+                          sortedCorrectAnswers.length === sortedSelectedAnswers.length
+                        : normalizedSelected[0] === correctAnswers[0]
+                : false
 
 	return (
 		<div className="question-card">
@@ -18,88 +42,105 @@ const QuestionCard = ({
 				{question.options.map((option, index) => {
 					let buttonClass = "option-button"
 
-					if (showAnswerResult) {
-						if (index === question.correctAnswer) {
-							buttonClass += " correct-answer"
-						} else if (
-							index === selectedAnswer &&
-							selectedAnswer !== question.correctAnswer
-						) {
-							buttonClass += " incorrect-answer"
-						}
-					} else if (selectedAnswer === index) {
-						buttonClass += " selected"
-					}
+                                        const isSelected = normalizedSelected.includes(index)
 
-					return (
-						<button
-							key={index}
-							onClick={() => onAnswerSelect(index)}
-							className={buttonClass}
-							disabled={showAnswerResult}
-						>
+                                        if (showAnswerResult) {
+                                                if (correctAnswers.includes(index)) {
+                                                        buttonClass += " correct-answer"
+                                                } else if (isSelected) {
+                                                        buttonClass += " incorrect-answer"
+                                                }
+                                        } else if (isSelected) {
+                                                buttonClass += " selected"
+                                        }
+
+                                        return (
+                                                <button
+                                                        key={index}
+                                                        onClick={() => onAnswerSelect(index)}
+                                                        className={buttonClass}
+                                                        disabled={showAnswerResult}
+                                                >
 							<span className="option-letter">
 								{String.fromCharCode(97 + index)}
 							</span>
 							<span className="option-text">{option}</span>
-							{showAnswerResult &&
-								index === question.correctAnswer && (
-									<span className="answer-indicator">✓</span>
-								)}
-							{showAnswerResult &&
-								index === selectedAnswer &&
-								selectedAnswer !== question.correctAnswer && (
-									<span className="answer-indicator">✗</span>
-								)}
-						</button>
-					)
-				})}
-			</div>
+                                                        {showAnswerResult &&
+                                                                correctAnswers.includes(index) && (
+                                                                        <span className="answer-indicator">✓</span>
+                                                                )}
+                                                        {showAnswerResult &&
+                                                                !correctAnswers.includes(index) &&
+                                                                isSelected && (
+                                                                        <span className="answer-indicator">✗</span>
+                                                                )}
+                                                </button>
+                                        )
+                                })}
+                        </div>
 
-			{showAnswerResult && (
+                        {showAnswerResult && (
 				<div
-					className={`answer-feedback ${
-						isCorrect ? "correct" : "incorrect"
-					}`}
-				>
-					{isCorrect ? (
-						<div className="feedback-content">
-							<span className="feedback-icon">🎉</span>
+                                        className={`answer-feedback ${
+                                                isCorrect ? "correct" : "incorrect"
+                                        }`}
+                                >
+                                        {isCorrect ? (
+                                                <div className="feedback-content">
+                                                        <span className="feedback-icon">🎉</span>
 							<span className="feedback-text">
 								Correct! Well done!
 							</span>
 						</div>
 					) : (
 						<div className="feedback-content">
-							<span className="feedback-icon">❌</span>
-							<span className="feedback-text">
-								Incorrect. The correct answer is:{" "}
-								<strong>
-									{question.options[question.correctAnswer]}
-								</strong>
-							</span>
-						</div>
-					)}
+                                                        <span className="feedback-icon">❌</span>
+                                                        <span className="feedback-text">
+                                                                Incorrect. The correct answer is:{" "}
+                                                                <strong>
+                                                                        {correctAnswers
+                                                                                .map((answerIndex) =>
+                                                                                        question.options[answerIndex],
+                                                                                )
+                                                                                .join(", ")}
+                                                                </strong>
+                                                        </span>
+                                                </div>
+                                        )}
 				</div>
 			)}
 
 			<div className="question-navigation">
-				<span className="navigation-hint">
-					{!showAnswerResult
-						? "Select an answer to continue"
-						: "Click next to continue"}
-				</span>
+                                <span className="navigation-hint">
+                                        {!showAnswerResult
+                                                ? isMultiple
+                                                        ? "Select one or more answers and submit"
+                                                        : "Select an answer to continue"
+                                                : "Click next to continue"}
+                                </span>
 
-				<button
-					onClick={onNext}
-					disabled={!showAnswerResult}
-					className="btn btn-primary"
-				>
-					{isLastQuestion ? "Show Results" : "Next Question"} →
-				</button>
-			</div>
-		</div>
-	)
+                                <div className="navigation-buttons">
+                                        {isMultiple && !showAnswerResult && (
+                                                <button
+                                                        onClick={onSubmitAnswer}
+                                                        disabled={normalizedSelected.length === 0}
+                                                        className="btn btn-secondary"
+                                                >
+                                                        Submit Answer
+                                                </button>
+                                        )}
+
+                                        <button
+                                                onClick={onNext}
+                                                disabled={!showAnswerResult}
+                                                className="btn btn-primary"
+                                        >
+                                                {isLastQuestion ? "Show Results" : "Next Question"} →
+                                        </button>
+                                </div>
+                        </div>
+                </div>
+        )
 }
 
 export default QuestionCard

--- a/src/hooks/useQuiz.js
+++ b/src/hooks/useQuiz.js
@@ -1,75 +1,156 @@
-import { useState } from "react"
+import { useEffect, useMemo, useState } from "react"
+
+const shuffleArray = (array) => {
+        const shuffled = [...array]
+        for (let i = shuffled.length - 1; i > 0; i--) {
+                const j = Math.floor(Math.random() * (i + 1))
+                ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+        }
+        return shuffled
+}
+
+const arraysAreEqual = (arrA = [], arrB = []) => {
+        if (arrA.length !== arrB.length) {
+                return false
+        }
+
+        for (let i = 0; i < arrA.length; i++) {
+                if (arrA[i] !== arrB[i]) {
+                        return false
+                }
+        }
+
+        return true
+}
 
 export const useQuiz = (questions) => {
-	const [currentQuestion, setCurrentQuestion] = useState(0)
-	const [selectedAnswer, setSelectedAnswer] = useState(null)
-	const [userAnswers, setUserAnswers] = useState({})
-	const [showResults, setShowResults] = useState(false)
-	const [quizStarted, setQuizStarted] = useState(false)
-	const [showAnswerResult, setShowAnswerResult] = useState(false)
+        const [currentQuestion, setCurrentQuestion] = useState(0)
+        const [selectedAnswers, setSelectedAnswers] = useState([])
+        const [userAnswers, setUserAnswers] = useState({})
+        const [showResults, setShowResults] = useState(false)
+        const [quizStarted, setQuizStarted] = useState(false)
+        const [showAnswerResult, setShowAnswerResult] = useState(false)
+        const [shuffledQuestions, setShuffledQuestions] = useState(() =>
+                shuffleArray(questions),
+        )
 
-	const totalQuestions = questions.length
-	const currentQ = questions[currentQuestion]
+        useEffect(() => {
+                setShuffledQuestions(shuffleArray(questions))
+        }, [questions])
 
-	const handleAnswerSelect = (answerIndex) => {
-		if (showAnswerResult) return // Предотвращаем изменение ответа после показа результата
+        const totalQuestions = shuffledQuestions.length
+        const currentQ = shuffledQuestions[currentQuestion]
 
-		setSelectedAnswer(answerIndex)
-		setShowAnswerResult(true)
+        const handleAnswerSelect = (answerIndex) => {
+                if (!currentQ || showAnswerResult) return
 
-		// Сохраняем ответ пользователя
-		setUserAnswers((prev) => ({
-			...prev,
-			[currentQuestion]: answerIndex,
-		}))
-	}
+                const isMultiple = Array.isArray(currentQ.correctAnswers)
 
-	const handleNextQuestion = () => {
-		if (currentQuestion < totalQuestions - 1) {
-			setCurrentQuestion((prev) => prev + 1)
-			setSelectedAnswer(null)
-			setShowAnswerResult(false)
-		} else {
-			setShowResults(true)
-		}
-	}
+                if (isMultiple) {
+                        setSelectedAnswers((prev) => {
+                                const exists = prev.includes(answerIndex)
+                                if (exists) {
+                                        return prev.filter((index) => index !== answerIndex)
+                                }
+                                return [...prev, answerIndex].sort((a, b) => a - b)
+                        })
+                        return
+                }
 
-	const calculateScore = () => {
-		let correct = 0
-		questions.forEach((question, index) => {
-			if (userAnswers[index] === question.correctAnswer) {
-				correct++
-			}
-		})
-		return correct
-	}
+                setSelectedAnswers([answerIndex])
+                setShowAnswerResult(true)
+                setUserAnswers((prev) => ({
+                        ...prev,
+                        [currentQuestion]: answerIndex,
+                }))
+        }
 
-	const resetQuiz = () => {
-		setCurrentQuestion(0)
-		setSelectedAnswer(null)
-		setUserAnswers({})
-		setShowResults(false)
-		setQuizStarted(false)
-		setShowAnswerResult(false)
-	}
+        const handleSubmitAnswer = () => {
+                if (!currentQ || showAnswerResult || selectedAnswers.length === 0) {
+                        return
+                }
 
-	const startQuiz = () => {
-		setQuizStarted(true)
-	}
+                const isMultiple = Array.isArray(currentQ.correctAnswers)
 
-	return {
-		currentQuestion,
-		selectedAnswer,
-		userAnswers,
-		showResults,
-		quizStarted,
-		showAnswerResult,
-		totalQuestions,
-		currentQ,
-		handleAnswerSelect,
-		handleNextQuestion,
-		calculateScore,
-		resetQuiz,
-		startQuiz,
-	}
+                const answerToStore = isMultiple
+                        ? [...selectedAnswers].sort((a, b) => a - b)
+                        : selectedAnswers[0]
+
+                setUserAnswers((prev) => ({
+                        ...prev,
+                        [currentQuestion]: answerToStore,
+                }))
+                setShowAnswerResult(true)
+        }
+
+        const handleNextQuestion = () => {
+                if (currentQuestion < totalQuestions - 1) {
+                        setCurrentQuestion((prev) => prev + 1)
+                        setSelectedAnswers([])
+                        setShowAnswerResult(false)
+                } else {
+                        setShowResults(true)
+                }
+        }
+
+        const calculateScore = useMemo(() => {
+                return () => {
+                        let correct = 0
+
+                        shuffledQuestions.forEach((question, index) => {
+                                const userAnswer = userAnswers[index]
+
+                                if (Array.isArray(question.correctAnswers)) {
+                                        if (
+                                                Array.isArray(userAnswer) &&
+                                                arraysAreEqual(
+                                                        [...userAnswer].sort((a, b) => a - b),
+                                                        [...question.correctAnswers].sort((a, b) => a - b),
+                                                )
+                                        ) {
+                                                correct++
+                                        }
+                                } else if (userAnswer === question.correctAnswer) {
+                                        correct++
+                                }
+                        })
+
+                        return correct
+                }
+        }, [shuffledQuestions, userAnswers])
+
+        const resetQuiz = () => {
+                setCurrentQuestion(0)
+                setSelectedAnswers([])
+                setUserAnswers({})
+                setShowResults(false)
+                setQuizStarted(false)
+                setShowAnswerResult(false)
+                setShuffledQuestions(shuffleArray(questions))
+        }
+
+        const startQuiz = () => {
+                setShuffledQuestions(shuffleArray(questions))
+                setCurrentQuestion(0)
+                setSelectedAnswers([])
+                setShowAnswerResult(false)
+                setQuizStarted(true)
+        }
+
+        return {
+                currentQuestion,
+                selectedAnswers,
+                userAnswers,
+                showResults,
+                quizStarted,
+                showAnswerResult,
+                totalQuestions,
+                currentQ,
+                handleAnswerSelect,
+                handleSubmitAnswer,
+                handleNextQuestion,
+                calculateScore,
+                resetQuiz,
+                startQuiz,
+        }
 }


### PR DESCRIPTION
## Summary
- add support for multiple-answer questions with selection toggles and submission flow
- highlight correct and incorrect selections, adjust navigation UI, and style the new submit button
- shuffle quiz questions for each run and update scoring to handle single and multiple answers

## Testing
- npm run build *(fails: vite binary missing because dependencies cannot be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e376b292a8832ab8c9e9f88e6480bd